### PR TITLE
fix:头条新闻api 

### DIFF
--- a/routes/api/news/news_list.js
+++ b/routes/api/news/news_list.js
@@ -46,28 +46,17 @@ app.get('/:type', function(req, res) {
     var host = "m.toutiao.com";
     var path = path;
     var data = {}
-        //false:http请求  true:https请求
-    var cookiesHost = 'm.toutiao.com';
-    Server.httpHeadersGet(cookiesHost,{},'',false).then(function(headers){
-        console.log("GET toutiao cookies: "+headers['set-cookie']);
-        Server.httpGet(host, data, path, false,headers['set-cookie']).then(function(body) {
+    var cookies = 'tt_webid=6529387942473385486';
+    Server.httpGet(host, data, path, false,cookies).then(function(body) {
         res.send({
             code: 200,
             data: JSON.parse(body)['data'],
             msg: '',
         })
-
     }).catch(function(err) {
         res.send({
             code: 404,
             msg: '网络好像有点问题',
-        })
-        console.log(err)
-    });
-    }).catch(function(err){
-        res.send({
-            code:500,
-            msg: 'toutiao cookies fetch error'
         })
         console.log(err)
     });

--- a/routes/api/news/news_list.js
+++ b/routes/api/news/news_list.js
@@ -9,7 +9,7 @@ const app = express()
 const Server = require('../../../utils/httpServer');
 
 app.get('/:type', function(req, res) {
-    var type = parseInt(req.query.type);
+    var type = parseInt(req.params.type);
     var path;
     //0 热点新闻 1 社会新闻 2 娱乐新闻 3体育新闻 4美文 散文 5科技 6 财经 7 时尚
     switch (type) {

--- a/routes/api/news/news_list.js
+++ b/routes/api/news/news_list.js
@@ -47,8 +47,10 @@ app.get('/:type', function(req, res) {
     var path = path;
     var data = {}
         //false:http请求  true:https请求
-    console.log("m.toutiao.com" + path)
-    Server.httpGet(host, data, path, false).then(function(body) {
+    var cookiesHost = 'm.toutiao.com';
+    Server.httpHeadersGet(cookiesHost,{},'',false).then(function(headers){
+        console.log("GET toutiao cookies: "+headers['set-cookie']);
+        Server.httpGet(host, data, path, false,headers['set-cookie']).then(function(body) {
         res.send({
             code: 200,
             data: JSON.parse(body)['data'],
@@ -61,6 +63,13 @@ app.get('/:type', function(req, res) {
             msg: '网络好像有点问题',
         })
         console.log(err)
-    })
+    });
+    }).catch(function(err){
+        res.send({
+            code:500,
+            msg: 'toutiao cookies fetch error'
+        })
+        console.log(err)
+    });
 });
 module.exports = app;

--- a/utils/httpServer.js
+++ b/utils/httpServer.js
@@ -203,9 +203,54 @@ function httpPost(host, data, path, status) {
         post_req.end();
     });
 }
+/**
+ * http get headers网络请求封装
+ * @param {string} 域名
+ * @param {obj} 参数
+ * @param {string} 接口路径
+ * @param {bool} true false 是否为https
+ * @returns
+ */
+function httpHeadersGet(host, data, path, status){
+    console.log('===================HttpCookiesGet=====================');
+    var options = {
+        host: host,
+        port: 80,
+        path: path + querystring.stringify(data),
+        method: 'GET',
+        encoding: null,
+        headers: {
+            'Content-Type': 'text/html',
+            'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.96 Safari/537.36',
+        },
+    };
+    //判断是否为https请求
+    if (status) {
+        http = require('https');
+        options.port = 443;
+    }
+    return new Promise(function(resolve, reject) {
+        var get_req = http.request(options, function(response) {
+            //response.setEncoding('utf8');
+            response.on('data', function(chunk) {
+                
+            });
+
+            response.on('end', () => {
+                resolve(response.headers);
+            });
+
+            response.on('error', err => {
+                reject(err);
+            });
+        });
+        get_req.end();
+    });
+}
 module.exports = {
     httpGet,
     httpPost,
     httpMobileGet,
     ajaxGet,
+    httpHeadersGet,
 };

--- a/utils/httpServer.js
+++ b/utils/httpServer.js
@@ -18,7 +18,7 @@ const request = require('request');
  * @param {bool} true false 是否为https
  * @returns
  */
-function httpGet(host, data, path, status) {
+function httpGet(host, data, path, status,cookies='') {
     console.log('===================HttpGet=====================');
     var options = {
         host: host,
@@ -29,6 +29,7 @@ function httpGet(host, data, path, status) {
         headers: {
             'Content-Type': 'application/json',
             'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.96 Safari/537.36',
+            'Cookie': cookies,
         },
     };
     //判断是否为https请求

--- a/utils/httpServer.js
+++ b/utils/httpServer.js
@@ -204,54 +204,9 @@ function httpPost(host, data, path, status) {
         post_req.end();
     });
 }
-/**
- * http get headers网络请求封装
- * @param {string} 域名
- * @param {obj} 参数
- * @param {string} 接口路径
- * @param {bool} true false 是否为https
- * @returns
- */
-function httpHeadersGet(host, data, path, status){
-    console.log('===================HttpCookiesGet=====================');
-    var options = {
-        host: host,
-        port: 80,
-        path: path + querystring.stringify(data),
-        method: 'GET',
-        encoding: null,
-        headers: {
-            'Content-Type': 'text/html',
-            'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.96 Safari/537.36',
-        },
-    };
-    //判断是否为https请求
-    if (status) {
-        http = require('https');
-        options.port = 443;
-    }
-    return new Promise(function(resolve, reject) {
-        var get_req = http.request(options, function(response) {
-            //response.setEncoding('utf8');
-            response.on('data', function(chunk) {
-                
-            });
-
-            response.on('end', () => {
-                resolve(response.headers);
-            });
-
-            response.on('error', err => {
-                reject(err);
-            });
-        });
-        get_req.end();
-    });
-}
 module.exports = {
     httpGet,
     httpPost,
     httpMobileGet,
     ajaxGet,
-    httpHeadersGet,
 };


### PR DESCRIPTION
1. 头条新闻需要tt_webid=:number  这个cookie才能访问，否则返回403
2. utils里面的httpget方法增加一个cookies参数，便于处理需要cookies的请求
ps: 之前的pr请忽略（之前的每次请求都加入一个新cookie，会导致新闻列表页面无法刷新)